### PR TITLE
Allows additional 7.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Latest Stable Version](https://poser.pugx.org/prokki/htpasswd/version)](https://packagist.org/packages/prokki/htpasswd)
 [![Total Downloads](https://poser.pugx.org/prokki/htpasswd/downloads)](https://packagist.org/packages/prokki/htpasswd)
 [![License](https://poser.pugx.org/prokki/htpasswd/license)](https://packagist.org/packages/prokki/htpasswd)
-[![PHP v7.3](https://img.shields.io/badge/PHP-%E2%89%A57%2E3-0044aa.svg)](https://www.php.net/manual/en/migration73.new-features.php)
-[![PHP v7.3](https://img.shields.io/badge/Symfony-%E2%89%A54-0044aa.svg)](https://symfony.com/)
+[![PHP v7.2](https://img.shields.io/badge/PHP-%E2%89%A57%2E2-0044aa.svg)](https://www.php.net/manual/en/migration72.new-features.php)
+[![Symfony 4](https://img.shields.io/badge/Symfony-%E2%89%A54-0044aa.svg)](https://symfony.com/)
 
 This symfony user provider reads user from the [htpasswd file](http://httpd.apache.org/docs/current/misc/password_encryptions.html).
 
@@ -31,7 +31,7 @@ http://httpd.apache.org/docs/current/misc/password_encryptions.html.
   
 ## Requirements
 
-The usage of [**PHP v7.3**](https://www.php.net/manual/en/migration73.new-features.php) 
+The usage of [**PHP v7.2**](https://www.php.net/manual/en/migration72.new-features.php) 
 and [**Symfony 4**](https://symfony.com/doc/4.0/setup.html) is obligatory.
 
 

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
         }
     ],
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=7.2.0",
         "whitehat101/apr1-md5": "^1.0",
         "symfony/flex": "^1.4",
-        "symfony/security": "^4.3",
-        "symfony/config": "^4.3",
-        "symfony/dependency-injection": "^4.3"
+        "symfony/security-bundle": "^4.3|^5.2",
+        "symfony/config": "^4.3|^5.2",
+        "symfony/dependency-injection": "^4.3|^5.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.2"

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+];

--- a/src/Security/HtpasswdEncoder.php
+++ b/src/Security/HtpasswdEncoder.php
@@ -168,4 +168,9 @@ class HtpasswdEncoder implements PasswordEncoderInterface
             // *nux = plain or crypt
             self::HASH_CRYPT_OR_PLAIN;
     }
+
+    public function needsRehash(string $encoded): bool
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
- Allows additional 7.2 support (more users can benefit from the package)
- Uses `symfony/security-bundle` instead of `symfony/security`